### PR TITLE
fix: line tool init fix

### DIFF
--- a/packages/drawing/package-lock.json
+++ b/packages/drawing/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulms/ui-drawing",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/drawing/package.json
+++ b/packages/drawing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulms/ui-drawing",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "",
   "keywords": [
     "lerna"

--- a/packages/drawing/src/tools/line.js
+++ b/packages/drawing/src/tools/line.js
@@ -26,6 +26,10 @@ export class LineTool extends Base {
     this._shiftPressed = false
     this._startX = 0
     this._startY = 0
+
+    this._canvas.forEachObject((_) => {
+      Object.assign(_, { evented: false, selectable: false })
+    })
   }
 
   __pointCkick (x, y) {


### PR DESCRIPTION
Поправил багу, когда при выборе инструмента линия можно было все равно выделять другие объекты